### PR TITLE
Set up GH Actions to build static output

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,11 +33,18 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build -- --outDir static
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: './static'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+static
 dist-ssr
 *.local
 


### PR DESCRIPTION
## Summary
- ignore generated `static` directory
- build static assets in GH workflow before deploying

## Testing
- `npm ci`
- `npm run build -- --outDir static`


------
https://chatgpt.com/codex/tasks/task_e_6844beff655483338061d7a974fc347e