### PR TITLE
Add Docker support for Playwright tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,16 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -t iguessgame-playwright .
+      - name: Run Playwright tests
+        run: docker run --rm --ipc=host iguessgame-playwright

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/playwright:v1.52.0-jammy
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+CMD ["npm", "run", "test:e2e"]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ Try it now: https://ambrozy.github.io/iguessgame/
 ```bash
 npm test
 ```
+
+## Running E2E tests with Docker
+
+Build the Playwright image and execute the tests:
+
+```bash
+docker build -t iguessgame-playwright .
+docker run --rm --ipc=host iguessgame-playwright
+```
+
+This allows running the same container image locally and in CI.

--- a/e2e/basic.e2e.js
+++ b/e2e/basic.e2e.js
@@ -6,12 +6,12 @@ test('lose scenario', async ({ page }) => {
   // Force deterministic chest order so first chest is the losing one
   await page.addInitScript(() => { Math.random = () => 0; });
 
-  await page.goto('/');
+  await page.goto('./');
   await page.click('#start');
   await page.screenshot({ path: 'e2e/screenshots/start.png', fullPage: true });
 
   // Open the first chest which will contain "Lose"
-  await page.locator('.chest-container').first().click();
+  await page.locator('.chest-container').first().click({ force: true });
   await page.locator('.reward.lose').waitFor();
   await page.screenshot({ path: 'e2e/screenshots/lose.png', fullPage: true });
 });


### PR DESCRIPTION
## Summary
- add Dockerfile based on official Playwright image
- document how to run Playwright via Docker
- update e2e test for new base URL and animation issues
- add workflow to run Playwright tests in Docker on CI

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_684870e4b7c483338831b13039ced282